### PR TITLE
Adding active search capabilities to the table component

### DIFF
--- a/runtime/debug.html
+++ b/runtime/debug.html
@@ -223,6 +223,7 @@
     <script src="js/lib/classNames.js"></script>
     <script src="js/lib/react-input-autosize.js"></script>
     <script src="js/lib/react-select.js"></script>
+    <script src="js/lib/done-typing.js"></script>
 
     <script src="js/services/ajax.js"></script>
     <script src="js/services/model.js"></script>

--- a/runtime/js/components/table-container.js
+++ b/runtime/js/components/table-container.js
@@ -39,7 +39,7 @@ permissions and limitations under the License.
 
     }
 
-    function renderHeader(searchValue, outcomes, flowKey, isSearchEnabled, onSearchChanged, onSearchEntered, search, isObjectData, refresh, isDesignTime) {
+    function renderHeader(componentId, searchValue, outcomes, flowKey, isSearchEnabled, onSearchChanged, onSearchEntered, search, isObjectData, refresh, isDesignTime) {
 
         var lookUpKey = manywho.utils.getLookUpKey(flowKey);
         var headerElements = [];
@@ -69,7 +69,7 @@ permissions and limitations under the License.
                 buttonAttributes.disabled = 'disabled';
 
             searchElement = React.DOM.div({ className: 'input-group table-search' }, [
-                    React.DOM.input({ type: 'text', className: 'form-control', value: searchValue, placeholder: 'Search', onChange: onSearchChanged, onKeyUp: onSearchEntered }),
+                    React.DOM.input({ type: 'text', className: 'form-control', id: componentId + '-search', value: searchValue, placeholder: 'Search', onChange: onSearchChanged, onKeyUp: onSearchEntered }),
                     React.DOM.span({ className: 'input-group-btn' },
                         React.DOM.button(buttonAttributes,
                             React.DOM.span({ className: 'glyphicon glyphicon-search' }, null)
@@ -412,6 +412,15 @@ permissions and limitations under the License.
             this.handleResizeDebounced = manywho.utils.debounce(this.handleResize, 200);
             window.addEventListener('resize', this.handleResizeDebounced);
 
+            // Add a typing listener so the user doesn't need to actually hit the search button
+            var model = manywho.model.getComponent(this.props.id, this.props.flowKey);
+            if (model.isSearchable &&
+                manywho.settings.global('search.isActive', this.props.flowKey)) {
+
+                $('#' + this.props.id + '-search').donetyping(this.search.bind(null, true), null);
+
+            }
+
         },
 
         componentWillUnmount: function () {
@@ -560,7 +569,7 @@ permissions and limitations under the License.
                 validationElement,
                 React.DOM.div({ className: this.state.isVisible ? '' : ' hidden' }, [
                     fileUpload,
-                    renderHeader(state.search, headerOutcomes, this.props.flowKey, model.isSearchable, this.onSearchChanged, this.onSearchEnter, this.search, (model.objectDataRequest || model.fileDataRequest), this.refresh, this.props.isDesignTime),
+                    renderHeader(this.props.id, state.search, headerOutcomes, this.props.flowKey, model.isSearchable, this.onSearchChanged, this.onSearchEnter, this.search, (model.objectDataRequest || model.fileDataRequest), this.refresh, this.props.isDesignTime),
                     content,
                     renderFooter(state.page || 1, hasMoreResults, this.onNext, this.onPrev, this.props.isDesignTime),
                     React.createElement(manywho.component.getByName('wait'), { isVisible: state.loading, message: state.loading && state.loading.message, isSmall: true }, null)

--- a/runtime/js/lib/done-typing.js
+++ b/runtime/js/lib/done-typing.js
@@ -1,0 +1,47 @@
+//
+// $('#element').donetyping(callback[, timeout=1000])
+// Fires callback when a user has finished typing. This is determined by the time elapsed
+// since the last keystroke and timeout parameter or the blur event--whichever comes first.
+//   @callback: function to be called when even triggers
+//   @timeout:  (default=1000) timeout, in ms, to to wait before triggering event if not
+//              caused by blur.
+// Requires jQuery 1.7+
+//
+// Taken from: http://stackoverflow.com/questions/14042193/how-to-trigger-an-event-in-input-text-after-i-stop-typing-writing
+
+;(function($){
+    $.fn.extend({
+        donetyping: function(callback,timeout){
+            timeout = timeout || 1e3; // 1 second default timeout
+            var timeoutReference,
+                doneTyping = function(el){
+                    if (!timeoutReference) return;
+                    timeoutReference = null;
+                    callback.call(el);
+                };
+            return this.each(function(i,el){
+                var $el = $(el);
+                // Chrome Fix (Use keyup over keypress to detect backspace)
+                // thank you @palerdot
+                $el.is(':input') && $el.on('keyup keypress paste',function(e){
+                    // This catches the backspace button in chrome, but also prevents
+                    // the event from triggering too preemptively. Without this line,
+                    // using tab/shift+tab will make the focused element fire the callback.
+                    if (e.type=='keyup' && e.keyCode!=8) return;
+
+                    // Check if timeout has been set. If it has, "reset" the clock and
+                    // start over again.
+                    if (timeoutReference) clearTimeout(timeoutReference);
+                    timeoutReference = setTimeout(function(){
+                        // if we made it here, our timeout has elapsed. Fire the
+                        // callback
+                        doneTyping(el);
+                    }, timeout);
+                }).on('blur',function(){
+                    // If we can, fire the event since we're leaving the field
+                    doneTyping(el);
+                });
+            });
+        }
+    });
+})(jQuery);

--- a/runtime/js/services/settings.js
+++ b/runtime/js/services/settings.js
@@ -28,6 +28,9 @@ manywho.settings = (function (manywho, $) {
             files: 10,
             select: 250
         },
+        search: {
+            isActive: false
+        },
         collaboration: {
             uri: 'https://realtime.manywho.com'
         },


### PR DESCRIPTION
The table component could use the option for "active search" which basically means the user doesn't need to hit the search button. I've put in a listener that waits for the user to stop typing for 1 second before performing the search request to stop it from storming the underlying service with requests. You can test it out here (if you can login to our demo salesforce org):

http://localhost:3000/debug.html?tenant-id=4dc56bec-b68c-47ac-8998-7ba961734c18&
flow-id=fae5b62a-589c-4618-bdb5-682f1f0dd3b0
