### PR TITLE
Improving the select filter logic to support start and any

### DIFF
--- a/runtime/js/components/select.js
+++ b/runtime/js/components/select.js
@@ -75,6 +75,12 @@ permissions and limitations under the License.
                 placeholder: model.hintValue || 'Please select an option'
             };
 
+            var matchPosition = manywho.settings.global('search.matchPosition', this.props.flowKey);
+
+            if (manywho.utils.isNullOrWhitespace(matchPosition) == false) {
+                selectAttributes.matchPos = matchPosition;
+            }
+
             var wrapperClasses = ['select-wrapper'];
 
             if (!manywho.utils.isEmptyObjectData(model) && !this.props.isDesignTime) {

--- a/runtime/js/services/settings.js
+++ b/runtime/js/services/settings.js
@@ -28,6 +28,9 @@ manywho.settings = (function (manywho, $) {
             files: 10,
             select: 250
         },
+        search: {
+            matchPosition: 'any'
+        },
         collaboration: {
             uri: 'https://realtime.manywho.com'
         },


### PR DESCRIPTION
The current 'select' implementation only supports 'any' matching which means typing in 'na' will return all states that have 'na' anywhere in the spelling. It's helpful to have 'start' matching where only results that start with the pattern are returned.

A test flow is available here:
http://localhost:3000/debug.html?tenant-id=870bc2ae-2e02-42c0-abc3-46ab584522c7&flow-id=0f84f158-2b78-490e-a07d-541fe4bd8b54
