### PR TITLE
FLOW-2529 - Remove jquery from default player

### DIFF
--- a/default.html
+++ b/default.html
@@ -121,8 +121,6 @@
         </div>
     </div>
 
-    <script src="{{cdnurl}}/js/vendor/jquery-2.1.4.min.js"></script>
-
     <script>
         var manywho = {
             cdnUrl: '{{cdnurl}}',


### PR DESCRIPTION
Removed the unnecessary jquery script reference in the default player. Jquery is loaded elsewhere with the other vendor scripts.